### PR TITLE
Revamp landing page with minimalistic futuristic design

### DIFF
--- a/screenstakeios/ContentView.swift
+++ b/screenstakeios/ContentView.swift
@@ -9,13 +9,29 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        ZStack {
+            LinearGradient(
+                colors: [.black, .purple.opacity(0.8)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Image(systemName: "camera.viewfinder")
+                    .font(.system(size: 72, weight: .thin))
+                    .foregroundStyle(.white)
+
+                Text("Screenstake")
+                    .font(.system(.largeTitle, design: .rounded))
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+
+                Text("Capture the future")
+                    .font(.footnote)
+                    .foregroundStyle(.gray)
+            }
         }
-        .padding()
     }
 }
 

--- a/screenstakeios/RootContainerView.swift
+++ b/screenstakeios/RootContainerView.swift
@@ -11,20 +11,31 @@ struct RootContainerView: View {
         TabView {
             // Home Tab
             NavigationStack {
-                VStack(spacing: 20) {
-                    Image(systemName: "camera.viewfinder")
-                        .font(.system(size: 60))
-                        .foregroundStyle(.tint)
-                    
-                    Text("Screenstake")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                    
-                    Text("Ready to capture screenshots")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                ZStack {
+                    // Futuristic gradient background
+                    LinearGradient(
+                        colors: [.black, .purple.opacity(0.8)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .ignoresSafeArea()
+
+                    VStack(spacing: 24) {
+                        Image(systemName: "camera.viewfinder")
+                            .font(.system(size: 72, weight: .thin))
+                            .foregroundStyle(.white)
+
+                        Text("Screenstake")
+                            .font(.system(.largeTitle, design: .rounded))
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.white)
+
+                        Text("Capture the future")
+                            .font(.footnote)
+                            .foregroundStyle(.gray)
+                    }
                 }
-                .navigationTitle("Home")
+                .toolbar(.hidden, for: .navigationBar)
             }
             .tabItem {
                 Label("Home", systemImage: "house.fill")


### PR DESCRIPTION
## Summary
- Restyled home tab with a dark-to-purple gradient, neon icon, and futuristic tagline
- Mirrored the new minimalistic aesthetic in `ContentView` for previews

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e91e9c4c88323be2d912e74158fbc