### PR TITLE
chore: update Swift toolchain version

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -69,7 +69,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.screenstakeios.screenstakeios
         PRODUCT_NAME: screenstakeios
-        SWIFT_VERSION: 5.0
+        SWIFT_VERSION: 5.9
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1
         GENERATE_INFOPLIST_FILE: YES

--- a/screenstakeios.xcodeproj/project.pbxproj
+++ b/screenstakeios.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.0;
+                            SWIFT_VERSION = 5.9;
 			};
 			name = Release;
 		};
@@ -354,7 +354,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.screenstakeios.screenstakeios;
 				PRODUCT_NAME = screenstakeios;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
+                            SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -418,7 +418,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+                            SWIFT_VERSION = 5.9;
 			};
 			name = Debug;
 		};
@@ -463,7 +463,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.screenstakeios.screenstakeios;
 				PRODUCT_NAME = screenstakeios;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
+                            SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/screenstakeios/Models/StripePaymentManager.swift
+++ b/screenstakeios/Models/StripePaymentManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import PassKit
 import StripePaymentSheet
 import StripeApplePay
+import UIKit
 
 @MainActor
 class StripePaymentManager: NSObject, ObservableObject {
@@ -97,14 +98,14 @@ class StripePaymentManager: NSObject, ObservableObject {
         applePayConfig.paymentSummaryItems = [setupItem]
         
         // Add recurring payment notice
-        let recurringPayment = PKRecurringPaymentSummaryItem(
-            label: "Screenstake Limit Exceeded Fee",
-            amount: NSDecimalNumber(value: stakeAmount)
-        )
-        recurringPayment.intervalUnit = .day
-        recurringPayment.intervalCount = 1  // Daily limit
-        
         if #available(iOS 16.0, *) {
+            let recurringPayment = PKRecurringPaymentSummaryItem(
+                label: "Screenstake Limit Exceeded Fee",
+                amount: NSDecimalNumber(value: stakeAmount)
+            )
+            recurringPayment.intervalUnit = .day
+            recurringPayment.intervalCount = 1  // Daily limit
+
             applePayConfig.recurringPaymentRequest = PKRecurringPaymentRequest(
                 paymentDescription: "Charged when daily screen time limit is exceeded",
                 regularBilling: recurringPayment,


### PR DESCRIPTION
## Summary
- build with Swift 5.9 to support async/await and preview macros
- fix StripePaymentManager to import UIKit and guard recurring payment setup

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a9f062c8323847bf2d271aace3a