### PR TITLE
Fix Apple Pay controller initialization

### DIFF
--- a/screenstakeios/Models/StripePaymentManager.swift
+++ b/screenstakeios/Models/StripePaymentManager.swift
@@ -113,11 +113,8 @@ class StripePaymentManager: NSObject, ObservableObject {
             )
         }
         
-        guard let authController = PKPaymentAuthorizationController(paymentRequest: applePayConfig) else {
-            completion(.failure(PaymentError.applePaySetupFailed))
-            return
-        }
-        
+        let authController = PKPaymentAuthorizationController(paymentRequest: applePayConfig)
+
         authController.delegate = self
         authController.present { presented in
             if !presented {


### PR DESCRIPTION
## Summary
- Remove optional binding around `PKPaymentAuthorizationController` since its initializer is non-failable

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a51e18c6a48323b3e1dd223f32c822