### PR TITLE
Fix Apple Pay controller and 3DS params

### DIFF
--- a/screenstakeios/Models/StripePaymentManager.swift
+++ b/screenstakeios/Models/StripePaymentManager.swift
@@ -9,6 +9,7 @@ import Foundation
 import PassKit
 import StripePaymentSheet
 import StripeApplePay
+import StripePayments
 import UIKit
 
 @MainActor
@@ -113,11 +114,8 @@ class StripePaymentManager: NSObject, ObservableObject {
             )
         }
         
-        guard let authController = PKPaymentAuthorizationController(paymentRequest: applePayConfig) else {
-            completion(.failure(PaymentError.applePaySetupFailed))
-            return
-        }
-        
+        let authController = PKPaymentAuthorizationController(paymentRequest: applePayConfig)
+
         authController.delegate = self
         authController.present { presented in
             if !presented {
@@ -205,8 +203,9 @@ class StripePaymentManager: NSObject, ObservableObject {
     func handle3DSAuthentication(clientSecret: String) async throws {
         // Present 3DS challenge using Stripe SDK
         try await withCheckedThrowingContinuation { continuation in
+            let params = STPPaymentIntentParams(clientSecret: clientSecret)
             STPPaymentHandler.shared().confirmPayment(
-                withParams: STPConfirmPaymentParams(clientSecret: clientSecret),
+                withParams: params,
                 authenticationContext: self
             ) { status, _, error in
                 switch status {


### PR DESCRIPTION
## Summary
- Remove optional binding around `PKPaymentAuthorizationController` since its initializer is non-failable
- Import `StripePayments` and use `STPPaymentIntentParams` for 3DS authentication

## Testing
- `xcodegen --version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a51e18c6a48323b3e1dd223f32c822